### PR TITLE
Improve CLI release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ OPTIONS:
   --verbose
   -h, --help              Show help information.
 ```
+
+## Release process
+
+Create a Github release 
+Publish Github release
+Run the `./build.sh` to create the artifactbundle 
+Upload the `artifactbundle` to the corresponding release page 
+Update [checksum](https://github.com/mackoj/PackageGeneratorPlugin/blob/2d2eb7e7c63a898bd71b14de8cd5acaab36eb7d2/Package.swift#L18) in https://github.com/mackoj/PackageGeneratorPlugin.

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,6 @@ swift package compute-checksum $CLI.artifactbundle.zip
 
 echo "Cleaning"
 rm -rf $CLI.artifactbundle
-rm -rf "$TMPRELEASEFOLDER"
-
+cp $CLI.artifactbundle.zip "$SOURCEFOLDER/$CLI.artifactbundle.zip"
 cd "$SOURCEFOLDER" || exit
+rm -rf "$TMPRELEASEFOLDER"

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,30 @@
 #!/usr/bin/env bash
 
 CLI="package-generator-cli"
+INFOJSONPATH="$CLI.artifactbundle/info.json"
+CLIBINPATH="$CLI.artifactbundle/arm64-apple-macosx/bin"
+TMPPATH=$(mktemp)
+TAG=$(curl -s "https://api.github.com/repos/mackoj/PackageGeneratorCLI/tags" | jq --compact-output --raw-output '.[0].name ')
+
+
+echo "Building $TAG"
+git checkout $TAG
+
+echo "Building $TAG"
 swift build -c release
-mkdir -p $CLI.artifactbundle/arm64-apple-macosx/bin
-cp -f .build/release/$CLI $CLI.artifactbundle/arm64-apple-macosx/bin
-cp info.json $CLI.artifactbundle/info.json
+
+echo "Creating Artifactbundle"
+mkdir -p $CLIBINPATH
+cp -f .build/release/$CLI $CLIBINPATH
+cp info.json "$INFOJSONPATH"
+jq '.artifacts."package-generator-cli".version = "'"$TAG"'"' "$INFOJSONPATH" > "$TMPPATH"
+mv "$TMPPATH" "$INFOJSONPATH"
+
+echo "Zip Artifactbundle"
 zip -r $CLI.artifactbundle.zip $CLI.artifactbundle -x ".*" -x "__MACOSX"
+
+echo "Compute Checksum"
 swift package compute-checksum $CLI.artifactbundle.zip
+
+echo "Cleaning"
 rm -rf $CLI.artifactbundle

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,17 @@ CLI="package-generator-cli"
 INFOJSONPATH="$CLI.artifactbundle/info.json"
 CLIBINPATH="$CLI.artifactbundle/arm64-apple-macosx/bin"
 TMPPATH=$(mktemp)
+TMPRELEASEFOLDER=$(mktemp -d)
+TMPRELEASEPROJECT=$TMPRELEASEFOLDER/PackageGeneratorCLI
 TAG=$(curl -s "https://api.github.com/repos/mackoj/PackageGeneratorCLI/tags" | jq --compact-output --raw-output '.[0].name ')
+SOURCEFOLDER=$(pwd)
 
+cd "$TMPRELEASEFOLDER" || exit
+git clone --depth 1 --branch "$TAG"  https://github.com/mackoj/PackageGeneratorCLI.git
+cd "$TMPRELEASEPROJECT" || exit
 
 echo "Building $TAG"
-git checkout $TAG
+git checkout "$TAG"
 
 echo "Building $TAG"
 swift build -c release
@@ -28,3 +34,6 @@ swift package compute-checksum $CLI.artifactbundle.zip
 
 echo "Cleaning"
 rm -rf $CLI.artifactbundle
+rm -rf "$TMPRELEASEFOLDER"
+
+cd "$SOURCEFOLDER" || exit

--- a/info.json
+++ b/info.json
@@ -8,7 +8,7 @@
         {
           "path": "arm64-apple-macosx/bin/package-generator-cli",
           "supportedTriples": ["arm64-apple-macosx"]
-        },
+        }
       ]
     }
   }


### PR DESCRIPTION
The script `./build.sh` now does most of the work to reduce human error.